### PR TITLE
Update devcontainer configuration to use MongoDB instead of MySQL

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -3,35 +3,33 @@ services:
     build:
       dockerfile: ./Dockerfile
     volumes:
-      - ../..:/workspaces:cached   
-    network_mode: service:db
+      - ../..:/workspaces:cached
+    network_mode: service:mongo
     command: sleep infinity
     depends_on:
-      db:
+      mongo:
         condition: service_healthy
     environment:
       NODE_ENV: development
       NODE_OPTIONS: --enable-source-maps
-      MYSQL_HOST: db
-      MYSQL_PORT: 3306
-      MYSQL_USER: root
-      MYSQL_PASSWORD: octocat
-      MYSQL_DATABASE: value
 
-  db:
-    image: mysql
-    restart: unless-stopped
+
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - '27017:27017'
     environment:
-      MYSQL_ROOT_PASSWORD: octocat
-      MYSQL_DATABASE: value
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: octocat
     volumes:
-      - db:/var/lib/mysql
+      - mongo-data:/data/db
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
-      interval: 5s
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')", "-u", "root", "-p", "octocat", "--authenticationDatabase", "admin"]
+      interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 20s
 
 volumes:
-  db:
+  mongo-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
-  "name": "Austen",
+  "name": "github-value-app",
   "dockerComposeFile": "./compose.yml",
   "service": "dev",
   "remoteUser": "node",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "postCreateCommand": "cd /workspaces/${localWorkspaceFolderBasename}/frontend && npm install && npm run build && cd /workspaces/${localWorkspaceFolderBasename}/backend && npm install",
+  "postCreateCommand": "cd /workspaces/${localWorkspaceFolderBasename}/frontend && npm install && npm run build && cd /workspaces/${localWorkspaceFolderBasename}/backend && npm install && npm run build && cd /workspaces/${localWorkspaceFolderBasename}",
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
@@ -18,18 +18,15 @@
         "gitlens.showWhatsNewAfterUpgrades": false
       },
       "extensions": [
-        "eamodio.gitlens",
         "ms-vscode.vscode-typescript-next",
         "dbaeumer.vscode-eslint",
-        "visualstudioexptteam.vscodeintellicode",
         "Angular.ng-template",
-        "sibiraj-s.vscode-scss-formatter",
         "ms-azuretools.vscode-docker",
-        "ms-vsliveshare.vsliveshare",
         "Github.vscode-github-actions",
         "GitHub.copilot",
         "GitHub.copilot-chat",
-        "GitHub.vscode-pull-request-github"
+        "GitHub.vscode-pull-request-github",
+        "mongodb.mongodb-vscode"
       ]
     }
   }


### PR DESCRIPTION
This pull request includes significant changes to the development environment configuration, specifically switching from MySQL to MongoDB, and updating the development container settings.

Changes in database service configuration:

* [`.devcontainer/compose.yml`](diffhunk://#diff-85dc84cf35cfe2518db19af9c6e123046c01aa36bbe707e6ce5d469ea9dd1d43L7-R35): Replaced the MySQL service with MongoDB, including updates to the network mode, service dependencies, environment variables, and healthcheck configurations.

Updates to devcontainer setup:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L2-R7): Changed the container name from "Austen" to "github-value-app" and updated the `postCreateCommand` to include a build step for the backend.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L21-R29): Updated the list of VSCode extensions, removing several unrelated extensions and adding the MongoDB extension.