### PR TITLE
Add MongoDB URI and PORT environment variables to devcontainer config…

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -10,8 +10,10 @@ services:
       mongo:
         condition: service_healthy
     environment:
+      PORT: 8080
       NODE_ENV: development
       NODE_OPTIONS: --enable-source-maps
+      MONGODB_URI: mongodb://root:octocat@mongo:27017
 
 
   mongo:


### PR DESCRIPTION
This pull request includes significant changes to the development container configuration, primarily switching the database service from MySQL to MongoDB and updating related settings. Additionally, there are updates to the `devcontainer.json` file to adjust the container name, post-create commands, and the list of installed extensions.

* [`.devcontainer/compose.yml`](diffhunk://#diff-85dc84cf35cfe2518db19af9c6e123046c01aa36bbe707e6ce5d469ea9dd1d43R13-R16): Added `PORT` and `MONGODB_URI` environment variables to the `services` section.